### PR TITLE
add db migration for new correct key types

### DIFF
--- a/spv/chain/neutrino.go
+++ b/spv/chain/neutrino.go
@@ -466,6 +466,8 @@ func (s *NeutrinoClient) NotifyReceived(addrs []ltcutil.Address) error {
 	// addresses to the watch list.
 	if s.scanning {
 		s.clientMtx.Unlock()
+		// Send a notification to the rescan loop to add the address to the
+		// filter data.
 		return s.rescan.Update(neutrino.AddAddrs(addrs...))
 	}
 

--- a/waddrmgr/scoped_manager.go
+++ b/waddrmgr/scoped_manager.go
@@ -269,6 +269,13 @@ var (
 		},
 	}
 
+	litecoinKeyScopes = []KeyScope{
+		KeyScopeBIP0049Plus,
+		KeyScopeBIP0084,
+		KeyScopeBIP0086,
+		KeyScopeBIP0044,
+	}
+
 	// KeyScopeBIP0049AddrSchema is the address schema for the traditional
 	// BIP-0049 derivation scheme. This exists in order to support importing
 	// accounts from other wallets that don't use our modified BIP-0049
@@ -505,6 +512,7 @@ func (s *ScopedKeyManager) loadAccountInfo(ns walletdb.ReadBucket,
 
 		// Use the crypto public key to decrypt the account public
 		// extended key.
+
 		acctInfo.acctKeyPub, err = decryptKey(
 			s.rootManager.cryptoKeyPub, row.pubKeyEncrypted,
 		)

--- a/wallet/recovery.go
+++ b/wallet/recovery.go
@@ -72,6 +72,8 @@ func (rm *RecoveryManager) Resurrect(ns walletdb.ReadBucket,
 			ns, waddrmgr.DefaultAccountNum,
 		)
 		if err != nil {
+			// If we're upgrading to v9, we might not have an account until we
+			// unlock.
 			return err
 		}
 


### PR DESCRIPTION
Add a db migration that adds the new correct litecoin key scopes with coin type = 2. We can't generate the coin-type keys until the user unlocks the wallet, so we check if we need to finish the upgrade on unlock.

Working with dexc, but still looking into adding tests here.